### PR TITLE
Handle colon and slashes inside square brackets

### DIFF
--- a/ioc_fanger/fang.json
+++ b/ioc_fanger/fang.json
@@ -6,6 +6,10 @@
         "comment": "Fang a period or comma preceded by parenthesis or square brackets (and possibly postceded by the same). A period or comma preceded by a close parenthesis is ignored (not fanged) to avoid pulling in false positives (e.g. to avoid fanging something like: 'Buy some milk (and eggs).')."
     },
     {
+        "find": "[://]",
+        "replace": "://"
+    },
+    {
         "find": "( *[\\[\\]\\(\\)\\\\]* *)[\\.\\,]( *[\\[\\]\\(\\)]+ *)",
         "replace": ".",
         "regex": true,

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -232,6 +232,9 @@ def test_odd_schemes():
     s = 'https&://example.com/test.php https://example.com/test.php http&://example.com/test.php xxXpA://example.com/test.php'
     assert ioc_fanger.fang(s) == 'https://example.com/test.php https://example.com/test.php https://example.com/test.php https://example.com/test.php'
 
+    s = 'hxxps[://]example[.]com/test[.]html'
+    assert ioc_fanger.fang(s) == 'https://example.com/test.html'
+
 
 def test_odd_email_address_spacing():
     s = "foo@barDOTcom"


### PR DESCRIPTION
Hey there,

I noticed that [few blogs](https://blog.malwarebytes.com/threat-analysis/2019/07/exploit-kits-summer-2019-review/) put colon and two forward slashes inside square brackets.

This PR handles this case.